### PR TITLE
updated version file.  Tested.

### DIFF
--- a/GameData/AviationLights/Plugins/AviationLights.version
+++ b/GameData/AviationLights/Plugins/AviationLights.version
@@ -11,8 +11,8 @@
   "KSP_VERSION": 
   {
     "MAJOR": 1,
-    "MINOR": 8,
-    "PATCH": 0
+    "MINOR": 9,
+    "PATCH": 2
   },
   "KSP_VERSION_MIN":
   {
@@ -23,7 +23,7 @@
   "KSP_VERSION_MAX":
   {
     "MAJOR": 1,
-    "MINOR": 8,
-    "PATCH": 9
+    "MINOR": 9,
+    "PATCH": 2
   }
 }


### PR DESCRIPTION
Updated the version file and tested to make sure it still works in KSP 1.9.2.  Seems to work fine.  I don't know what to test against as far as conflicts go, but MechJeb 2.0 and AviationLights seem to work well together (the only two mods that I have installed).