### PR TITLE
Let it work in KSP 1.10, also as a spotlight

### DIFF
--- a/GameData/AviationLights/Plugins/AviationLights.version
+++ b/GameData/AviationLights/Plugins/AviationLights.version
@@ -6,24 +6,24 @@
   {
     "MAJOR": 4,
     "MINOR": 1,
-    "PATCH": 0
+    "PATCH": 1
   },
   "KSP_VERSION": 
   {
     "MAJOR": 1,
-    "MINOR": 8,
+    "MINOR": 10,
     "PATCH": 0
   },
   "KSP_VERSION_MIN":
   {
   	"MAJOR": 1,
   	"MINOR": 8,
-	"PATCH": 0
+	  "PATCH": 0
   },
   "KSP_VERSION_MAX":
   {
     "MAJOR": 1,
-    "MINOR": 8,
-    "PATCH": 9
+    "MINOR": 10,
+    "PATCH": 99
   }
 }

--- a/Source/AviationLights.cs
+++ b/Source/AviationLights.cs
@@ -1,3 +1,9 @@
+/***************************************************************************************/
+/* PROJECT CONFIG:                                                                     */
+/* Set env variable KSPFolder to wherever your KSP is installed and reopen the project */
+/* to have get all project paths working wherecer your KSP resides.                    */
+/***************************************************************************************/
+
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -42,7 +48,7 @@ namespace AviationLights
         public float actualEnergyReq = 0.0f;
 
         [KSPField]
-        public float SpotAngle = 0.0f;
+        public float SpotAngle = 160.0f;
 
         [KSPField(isPersistant = true)]
         public float Interval = 1.0f;

--- a/Source/AviationLights.cs
+++ b/Source/AviationLights.cs
@@ -1,7 +1,7 @@
 /***************************************************************************************/
 /* PROJECT CONFIG:                                                                     */
 /* Set env variable KSPFolder to wherever your KSP is installed and reopen the project */
-/* to have get all project paths working wherecer your KSP resides.                    */
+/* to have get all project paths working wherever your KSP resides.                    */
 /***************************************************************************************/
 
 using System;

--- a/Source/AviationLights.csproj
+++ b/Source/AviationLights.csproj
@@ -33,16 +33,16 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(KSPFolder)\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(KSPFolder)\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(KSPFolder)\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -51,8 +51,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(TargetPath) $(SolutionDir)..\GameData\AviationLights\Plugins
-copy $(TargetPath) "D:\Games\Steam\steamapps\common\Kerbal Space Program\GameData\AviationLights\Plugins\"</PostBuildEvent>
+    <PostBuildEvent>echo Copying $(TargetFileName) to projet output folder
+copy "$(TargetPath)" "$(SolutionDir)..\GameData\AviationLights\Plugins"
+echo Deploying $(TargetFileName) to $(KSPFolder)
+copy "$(TargetPath)" "$(KSPFolder)\GameData\AviationLights\Plugins\"</PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PreBuildEvent>If not exist "$(KSPFolder)"\. echo Define KSPFolder env var to there your copy of KSP resides</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
    Change: Updated version file
    Reason: yes, it works with KSP 1.10

    Change: Reconfigured project file to use env var KSPFolder
    Reason: Paths in project pointed to non-standard KSP location.
            Using the KSPFolder env var solves lest anybody to have own
            KSP's location without need of modifying the prj file. There is
            also comment in code and pre-build message printed to inform
            contributors about the var.

    Change: Spot light angle set to 160 deg
    Reason: Value of 0 disabled spot light capability yet it still could be set
            in UI - but with no effect. Spot light mode works and is desired.
