### PR TITLE
Pretty lame mistake fixed

### DIFF
--- a/GameData/AviationLights/Localization/pt-br.cfg
+++ b/GameData/AviationLights/Localization/pt-br.cfg
@@ -1,6 +1,6 @@
 Localization
 {
-	en-us
+	pt-br
 	{
 		#AL_ColorAmber = Âmbar
 		#AL_ColorBlue = Azul


### PR DESCRIPTION
I'm afraid I did a pretty lame mistake on my last pull request - I forgot to rename the localization node from "en-us" to "pr-br" on the file.

I rarely play with pt-br localisation, and I just didn't realised the whole game was en en-us while the Aviation Lights alone were in pt-br. Interesting enough, I'm playing with this configuration for months and my son was the one that hinted me about the weirdness… (sigh)

My apologies. This pull request fixes the blunder.